### PR TITLE
why don't we let people choose the status code?

### DIFF
--- a/pico/__init__.py
+++ b/pico/__init__.py
@@ -94,9 +94,10 @@ class JSONString(str):
 
 
 class PicoError(Exception):
-    def __init__(self, message=''):
+    def __init__(self, message='', status=500):
         Exception.__init__(self, message)
-        self.response = Response(status="500 " + message, content=message)
+        self.response = Response(status="%s %s" % (status, message),
+                                 content=message)
 
     def __str__(self):
         return repr(self.message)


### PR DESCRIPTION
This is the only way that i found to set the status code for a request. 

```
import pico

def teapot():
    try:
        brew_coffee()
        return "Smells nice!"
    except TeapotError:
        raise PicoError("I'm a teapot", status=418)
```