### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-##Install
+## Install
 `easy_install pico`
 or
 `pip install pico`
 
 
-##Write a Python module:
+## Write a Python module:
 ```python
 # example.py
 import pico
@@ -19,7 +19,7 @@ def hello(name="World"):
 
 Or run behind Apache with mod_wsgi
 
-##Call your Python functions from Javascript:
+## Call your Python functions from Javascript:
 
 ```html
 <!DOCTYPE HTML>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
