### PR TITLE
Update Werkzeug dependancy to 0.16.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     download_url='https://github.com/fergalwalsh/pico/tarball/%s' % version,
     packages=['pico', 'pico.extras'],
     test_suite='nose2.collector.collector',
-    install_requires=['wrapt >= 1.8.0', 'Werkzeug >= 0.12.1', 'requests >= 2.9.1'],
+    install_requires=['wrapt >= 1.8.0', 'Werkzeug >= 0.16.1', 'requests >= 2.9.1'],
     include_package_data=True,
     classifiers=(
         'Programming Language :: Python',


### PR DESCRIPTION
PR #21 fixed the import of `SharedDataMiddleware` in recent versions but it didn't bump the requirement to the version of Werkzeug when the import was changed. This PR fixes that.