### PR TITLE
support Python 3.11+, Werkzeug 2.0+

### DIFF
--- a/pico/__init__.py
+++ b/pico/__init__.py
@@ -150,7 +150,7 @@ class PicoApp(object):
     def function_definition(self, func, pico_url='/'):
         annotations = dict(func._annotations)
         request_args = set(annotations.pop('request_args', []))
-        a = inspect.getargspec(func)
+        a = inspect.getfullargspec(func)
         args = []
         for i, arg_name in enumerate(a.args):
             if arg_name and arg_name != 'self' and arg_name not in request_args:
@@ -165,7 +165,7 @@ class PicoApp(object):
             url=self.func_url(func, pico_url),
             args=args,
         )
-        if a.keywords is not None:
+        if a.varkw is not None:
             d['accept_extra_args'] = True
         d.update(annotations)
         return d

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     download_url='https://github.com/fergalwalsh/pico/tarball/%s' % version,
     packages=['pico', 'pico.extras'],
     test_suite='nose2.collector.collector',
-    install_requires=['wrapt >= 1.8.0', 'Werkzeug >= 0.16.1', 'requests >= 2.9.1'],
+    install_requires=['wrapt >= 1.8.0', 'Werkzeug >= 2.0.0', 'requests >= 2.9.1'],
     include_package_data=True,
     classifiers=(
         'Programming Language :: Python',

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,7 +5,7 @@ import unittest
 from io import BytesIO
 
 from werkzeug.test import Client
-from werkzeug.wrappers import BaseResponse
+from werkzeug.wrappers import Response
 
 import testapp
 
@@ -13,7 +13,7 @@ import testapp
 class TestApp(unittest.TestCase):
 
     def setUp(self):
-        self.client = Client(testapp.app, BaseResponse)
+        self.client = Client(testapp.app, Response)
 
     def test_hello_get(self):
         r = self.client.get('/testapp/hello/?who=Tester')


### PR DESCRIPTION
* inspect.getargspec() was removed from Python 3.11+
* BaseResponse was removed from Werkzeug 2.1.0+